### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,9 @@ name: Go
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   GOLANGCI_VERSION: "v2.4.0"
 


### PR DESCRIPTION
Potential fix for [https://github.com/intility/go-jwks/security/code-scanning/2](https://github.com/intility/go-jwks/security/code-scanning/2)

To fix the problem, explicitly define `permissions` for the workflow (or for each job) so that the `GITHUB_TOKEN` has only the least privileges required. Since all jobs here only need to read repository contents, the minimal safe default is `contents: read`.

The best fix without changing functionality is:

- Add a `permissions` block at the root of `.github/workflows/go.yml`, alongside `name`, `on`, and `env`.
- Set `permissions: contents: read`, which applies to all jobs that don’t specify their own permissions.
- Do not modify the jobs themselves, as they only rely on reading code via `actions/checkout` and do not need write scopes.

Concretely:

- In `.github/workflows/go.yml`, between the `on:` block (line 3–4) and the `env:` block (line 6–8), insert:

  ```yaml
  permissions:
    contents: read
  ```

No additional methods, imports, or definitions are needed; this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
